### PR TITLE
add a default value for 'code_confidentialite'

### DIFF
--- a/python/enthic/extract_bundle.py
+++ b/python/enthic/extract_bundle.py
@@ -16,7 +16,7 @@ import xml.etree.ElementTree as ElementTree
 from csv import reader
 from io import BytesIO
 from json import load
-from logging import debug, basicConfig
+from logging import info, debug, basicConfig
 from os import listdir
 from os.path import dirname, join, isdir
 from re import sub, compile
@@ -153,7 +153,7 @@ def main():
     # CREATING A LIST OF THE BUNDLE XML CODES, ZIP ARE READ IN BtesIO, IN ORDER
     # TO BREAK FILE SYSTEM. TOO MUCH ZIP DISTURB THE FS.
     for file in listdir(CONFIG['inputPath']):  # LIST INPUT FILES
-        print("processing INPI daily zip file", file)
+        info("processing INPI daily zip file %s", file)
         if file.endswith(".zip"):  # ON RETAIN ZIP FILES
             try:  # SOME BAD ZIP FILE ARE IN HE DATASET
                 input_zip = ZipFile(join(CONFIG['inputPath'], file))

--- a/python/enthic/ontology.py
+++ b/python/enthic/ontology.py
@@ -1841,6 +1841,7 @@ CODE_MOTIF = {
 }
 
 CODE_CONFIDENTIALITE = {
+    -1 : "code non fourni",
     0 : "comptes annuels non confidentiels",
     1 : "comptes annuels confidentiels",
     2 : "compte de résultat confidentiel"

--- a/sh/clear-data.sh
+++ b/sh/clear-data.sh
@@ -21,6 +21,6 @@ rm -rf $DATA_DIR/*.md5>/dev/null 2>&1;
 rm -rf ../output/*.tmp>/dev/null 2>&1;
 ################################################################################
 # CONSIDERED AS TWO STEPS
-step "UNZIPING IN ${DATA_DIR}";
+step "PROCESSING INPI DAILY ZIP FILE IN ${DATA_DIR}";
 python3 ../python/enthic/extract_bundle.py -c ../configuration.json
 rm -rf $DATA_DIR/*.zip>/dev/null 2>&1;         # DELETE THE UNZIPPED FILE


### PR DESCRIPTION
In order to fix the issue #20 , this PR add a default value for 'code_confidentialite' so it doesn't crash if this code is not in an INPI's xml.
But I couldn't reproduce the bug locally because I don't know which input was used, that's whay I added a print line so the script print on which INPI daily zip it is working. So if it crash, it will be easier to reproduce using the same input.