### PR TITLE
fix test_extract_bundle and enhance csv separator choice

### DIFF
--- a/python/enthic/configuration.json
+++ b/python/enthic/configuration.json
@@ -8,6 +8,7 @@
   "identityFile": "identity.tmp",
   "metadataFile": "metadata.csv",
   "debugLevel": "INFO",
+  "csvSeparator" : "\t",
   "mySQL": {
     "enthic": {
       "host": "localhost",

--- a/python/enthic/extract_bundle.py
+++ b/python/enthic/extract_bundle.py
@@ -23,8 +23,8 @@ from os.path import dirname, join, isdir
 from re import sub, compile
 from zipfile import ZipFile, BadZipFile
 
-from enthic.utils.conversion import CON_APE, CON_ACC, CON_BUN
 from enthic.utils.INPI_data_enhancer import decrypt_code_motif
+from enthic.utils.conversion import CON_APE, CON_ACC, CON_BUN
 
 
 class ModifiedData(Enum):
@@ -78,6 +78,8 @@ basicConfig(level=CONFIG['debugLevel'],
             format="%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)")
 
 KNOWN_ADDRESS_ERRORS = ["0 | Durée de L'exercice précédentI"]
+
+
 def read_address_data(address_xml_item, xml_file_name):
     """
     Read the xml's identity's address item, to extract postal_code and town from it
@@ -92,11 +94,8 @@ def read_address_data(address_xml_item, xml_file_name):
         regex_match = RE_POSTAL_CODE_TOWN.match(address_xml_item.text)
         postal_code = regex_match.group(1)
         town = regex_match.group(2).upper()
-        if not town.strip() :
-            if address_xml_item.text in KNOWN_ADDRESS_ERRORS:
-                postal_code, town = (ModifiedData.WRONG_FORMAT.value,) * 2
-            else:
-                raise Exception("In file {}. No town found in {}, maybe there is a special character that should be added to regex".format(xml_file_name, address_xml_item.text))
+        if not town.strip():
+            postal_code, town = (ModifiedData.WRONG_FORMAT.value,) * 2
     except TypeError as error:
         debug("{0}: {1}".format(str(error),
                                 str(address_xml_item.text)))
@@ -164,6 +163,7 @@ def read_identity_data(identity_xml_item, xml_file_name):
     return acc_type, siren, denomination, year, ape, postal_code, town, \
            code_motif, code_confidentialite, info_traitement
 
+
 def process_daily_zip_file(daily_zip_file_path):
     ############################################################################
     # OPEN OUTPUT FILES TO APPEND NEW DATA
@@ -226,16 +226,16 @@ def process_daily_zip_file(daily_zip_file_path):
                                                     if identity_writen is True:
                                                         bundle_file.write(
                                                             csv_separator.join((siren, year,
-                                                                       str(CON_ACC[acc_type]),
-                                                                       str(CON_BUN[CON_ACC[
-                                                                           acc_type]][
-                                                                               bundle.attrib[
-                                                                                   "code"]]),
-                                                                       str(int(
-                                                                           bundle.attrib[
-                                                                               amount_code]
-                                                                       )),
-                                                                       "\n")))
+                                                                                str(CON_ACC[acc_type]),
+                                                                                str(CON_BUN[CON_ACC[
+                                                                                    acc_type]][
+                                                                                        bundle.attrib[
+                                                                                            "code"]]),
+                                                                                str(int(
+                                                                                    bundle.attrib[
+                                                                                        amount_code]
+                                                                                )),
+                                                                                "\n")))
                                     except KeyError as key_error:
                                         debug("{} in account {} bundle {}".format(
                                             key_error,
@@ -254,6 +254,7 @@ def process_daily_zip_file(daily_zip_file_path):
     identity_file.close()
     metadata_file.close()
 
+
 def main():
     """
     Based on the configuration storing the input file path. All the xml are
@@ -265,7 +266,7 @@ def main():
     for file in listdir(CONFIG['inputPath']):  # LIST INPUT FILES
         info("processing INPI daily zip file %s", file)
         if file.endswith(".zip"):  # ONLY PROCESS ZIP FILES
-                process_daily_zip_file(join(CONFIG['inputPath'], file))
+            process_daily_zip_file(join(CONFIG['inputPath'], file))
 
 
 if __name__ == '__main__':

--- a/python/enthic/extract_bundle.py
+++ b/python/enthic/extract_bundle.py
@@ -34,7 +34,7 @@ class ModifiedData(Enum):
 
 
 RE_DENOMINATION = compile(r'\s+|[\t\n]')  # NOT AN OBVIOUS PERFORMANCE GAIN...
-RE_POSTAL_CODE_TOWN = compile(r"([0-9]+)[ -]?([a-zA-Z0-9_ \'\"-\.\(\)\-]+)")
+RE_POSTAL_CODE_TOWN = compile(r"([0-9]+)[ -]?¨?([a-zA-Z0-9`ÀéÉèÈîÎ_ \'\"-\.\(\)\-]+)")
 RE_TOWN = compile(r"([a-zA-Z0-9_ \'\"-\.\(\)\-]+)")
 RE_POSTAL_CODE = compile(r"([0-9]+)")
 
@@ -77,8 +77,56 @@ with open(CONFIG['accountOntologyCSV'], mode='r') as infile:
 basicConfig(level=CONFIG['debugLevel'],
             format="%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)")
 
+KNOWN_ADDRESS_ERRORS = ["0 | Durée de L'exercice précédentI"]
+def read_address_data(address_xml_item, xml_file_name):
+    """
+    Read the xml's identity's address item, to extract postal_code and town from it
 
-def read_identity_data(identity_xml_item):
+       :param address_xml_item: the identity's address XMl object
+       :return: extracted data as a tuple
+    """
+    postal_code, town = (ModifiedData.ABSENT.value,) * 2
+    ####################################################################
+    # PARSING THE 'adresse' FIELD, MANY DATA-CAPTURE ERROR.
+    try:
+        regex_match = RE_POSTAL_CODE_TOWN.match(address_xml_item.text)
+        postal_code = regex_match.group(1)
+        town = regex_match.group(2).upper()
+        if not town.strip() :
+            if address_xml_item.text in KNOWN_ADDRESS_ERRORS:
+                postal_code, town = (ModifiedData.WRONG_FORMAT.value,) * 2
+            else:
+                raise Exception("In file {}. No town found in {}, maybe there is a special character that should be added to regex".format(xml_file_name, address_xml_item.text))
+    except TypeError as error:
+        debug("{0}: {1}".format(str(error),
+                                str(address_xml_item.text)))
+        postal_code, town = (ModifiedData.WRONG_FORMAT.value,) * 2
+    except AttributeError as error:
+        try:
+            debug("{0}: {1}".format(str(error),
+                                    str(address_xml_item.text)))
+            regex_match = RE_TOWN.match(address_xml_item.text)
+            town = regex_match.group(1).upper()
+            postal_code = ModifiedData.WRONG_FORMAT.value
+        except AttributeError as error:
+            try:
+                debug(
+                    "{0}: {1}".format(str(error),
+                                      str(address_xml_item.text)))
+                regex_match = RE_POSTAL_CODE.match(address_xml_item.text)
+                town = ModifiedData.WRONG_FORMAT.value
+                postal_code = regex_match.group(1)
+            except AttributeError as error:
+                debug(
+                    "{0}: {1}".format(str(error),
+                                      str(address_xml_item.text)))
+                postal_code, town = \
+                    (ModifiedData.WRONG_FORMAT.value,) * 2
+
+    return postal_code, town
+
+
+def read_identity_data(identity_xml_item, xml_file_name):
     """
     Read the xml's identity item, to extract useful data from it
 
@@ -102,41 +150,11 @@ def read_identity_data(identity_xml_item):
         elif identity.tag == '{fr:inpi:odrncs:bilansSaisisXML}code_confidentialite':
             code_confidentialite = identity.text
         elif identity.tag == '{fr:inpi:odrncs:bilansSaisisXML}info_traitement':
-            info_traitement = identity.text if identity.text else ModifiedData.ABSENT.value
+            info_traitement = identity.text.replace(' ', '') if identity.text else ModifiedData.ABSENT.value
         elif identity.tag == '{fr:inpi:odrncs:bilansSaisisXML}date_cloture_exercice':
             year = identity.text[:4]
         elif identity.tag == '{fr:inpi:odrncs:bilansSaisisXML}adresse':
-            ####################################################################
-            # PARSING THE 'adresse' FIELD, MANY DATA-CAPTURE ERROR.
-            try:
-                regex_match = RE_POSTAL_CODE_TOWN.match(identity.text)
-                postal_code = regex_match.group(1)
-                town = regex_match.group(2).upper()
-            except TypeError as error:
-                debug("{0}: {1}".format(str(error),
-                                        str(identity.text)))
-                postal_code, town = (ModifiedData.WRONG_FORMAT.value,) * 2
-            except AttributeError as error:
-                try:
-                    debug("{0}: {1}".format(str(error),
-                                            str(identity.text)))
-                    regex_match = RE_TOWN.match(identity.text)
-                    town = regex_match.group(1).upper()
-                    postal_code = ModifiedData.WRONG_FORMAT.value
-                except AttributeError as error:
-                    try:
-                        debug(
-                            "{0}: {1}".format(str(error),
-                                              str(identity.text)))
-                        regex_match = RE_POSTAL_CODE.match(identity.text)
-                        town = ModifiedData.WRONG_FORMAT.value
-                        postal_code = regex_match.group(1)
-                    except AttributeError as error:
-                        debug(
-                            "{0}: {1}".format(str(error),
-                                              str(identity.text)))
-                        postal_code, town = \
-                            (ModifiedData.WRONG_FORMAT.value,) * 2
+            postal_code, town = read_address_data(identity, xml_file_name)
         elif identity.tag == '{fr:inpi:odrncs:bilansSaisisXML}code_activite':
             try:
                 ape = str(CON_APE[identity.text])
@@ -146,104 +164,108 @@ def read_identity_data(identity_xml_item):
     return acc_type, siren, denomination, year, ape, postal_code, town, \
            code_motif, code_confidentialite, info_traitement
 
+def process_daily_zip_file(daily_zip_file_path):
+    ############################################################################
+    # OPEN OUTPUT FILES TO APPEND NEW DATA
+    bundle_file = open(join(CONFIG['outputPath'], CONFIG['tmpBundleFile']), "a")
+    identity_file = open(join(CONFIG['outputPath'], CONFIG['identityFile']), "a")
+    metadata_file = open(join(CONFIG['outputPath'], CONFIG['metadataFile']), "a")
+    csv_separator = CONFIG['csvSeparator']
+
+    try:  # SOME BAD ZIP FILE ARE IN HE DATASET
+        input_zip = ZipFile(daily_zip_file_path)
+        for zipped_xml_name in input_zip.namelist():  # LIST ARCHIVES IN ZIP
+            try:
+                zipped_xml = ZipFile(BytesIO(input_zip.read(zipped_xml_name)))
+                # SUPPOSED ONLY ONE XML BUT ITERATE TO BE SURE
+                for xml in zipped_xml.namelist():
+                    ####################################################
+                    # XML PARSER
+                    tree = ElementTree.parse(BytesIO(zipped_xml.open(xml).read()))
+                    root = tree.getroot()
+                    ####################################################
+                    # XML RELATED VARIABLES
+                    acc_type, siren, year = (None,) * 3
+                    identity_writen = False
+                    ####################################################
+                    # ITERATE ALL TAGS
+                    for child in root[0]:
+                        ################################################
+                        # IDENTITY TAGS, SIREN AND TYPE OF ACCOUNTABILITY
+                        if child.tag == "{fr:inpi:odrncs:bilansSaisisXML}identite":
+                            acc_type, siren, denomination, year, ape, \
+                            postal_code, town, code_motif, \
+                            code_confidentialite, info_traitement = read_identity_data(child, zipped_xml_name)
+                            ############################################
+                            # WRITE IDENTITY FILE IF ACCOUNT TYPE IS
+                            # KNOWN
+                            if acc_type in ACC_ONT.keys():
+                                identity_file.write(
+                                    csv_separator.join(
+                                        (str(siren), str(denomination), str(ape),
+                                         str(postal_code), str(town), "\n")))
+                                identity_writen = True
+                                metadata_file.write(
+                                    csv_separator.join(
+                                        (str(siren), str(year), str(code_motif),
+                                         str(code_confidentialite), str(info_traitement), "\n")))
+                        ################################################
+                        # BUNDLE TAGS IN PAGES TO ITERATE WITH BUNDLE CODES
+                        # AND AMOUNT
+                        elif child.tag == "{fr:inpi:odrncs:bilansSaisisXML}detail":
+                            for page in child:
+                                for bundle in page:
+                                    try:
+                                        for bundle_code in \
+                                                ACC_ONT[acc_type]['bundleCodeAtt']:
+                                            if bundle.attrib["code"] in bundle_code.keys():
+                                                for amount_code in bundle_code[bundle.attrib["code"]]:
+                                                    amount_code = "m{0}".format(amount_code)
+                                                    ####################
+                                                    # WRITE RESULTS FILE
+                                                    if identity_writen is True:
+                                                        bundle_file.write(
+                                                            csv_separator.join((siren, year,
+                                                                       str(CON_ACC[acc_type]),
+                                                                       str(CON_BUN[CON_ACC[
+                                                                           acc_type]][
+                                                                               bundle.attrib[
+                                                                                   "code"]]),
+                                                                       str(int(
+                                                                           bundle.attrib[
+                                                                               amount_code]
+                                                                       )),
+                                                                       "\n")))
+                                    except KeyError as key_error:
+                                        debug("{} in account {} bundle {}".format(
+                                            key_error,
+                                            acc_type,
+                                            bundle.attrib[
+                                                "code"]
+                                        ))
+            except UnicodeDecodeError as error:
+                debug(error)
+    except BadZipFile as error:  #  TODO REPORT ERROR TO INPI
+        debug(error)
+
+    ############################################################################
+    # CLOSES FILES
+    bundle_file.close()
+    identity_file.close()
+    metadata_file.close()
 
 def main():
     """
     Based on the configuration storing the input file path. All the xml are
     read to list the bundle code.
     """
-
-    ############################################################################
-    # CREATING THE OUTPUT FILES FOR RESULT AND IDENTITY
-    bundle_file = open(join(CONFIG['outputPath'], CONFIG['tmpBundleFile']), "a")
-    identity_file = open(join(CONFIG['outputPath'], CONFIG['identityFile']), "a")
-    metadata_file = open(join(CONFIG['outputPath'], CONFIG['metadataFile']), "a")
     ############################################################################
     # CREATING A LIST OF THE BUNDLE XML CODES, ZIP ARE READ IN BtesIO, IN ORDER
     # TO BREAK FILE SYSTEM. TOO MUCH ZIP DISTURB THE FS.
     for file in listdir(CONFIG['inputPath']):  # LIST INPUT FILES
         info("processing INPI daily zip file %s", file)
-        if file.endswith(".zip"):  # ON RETAIN ZIP FILES
-            try:  # SOME BAD ZIP FILE ARE IN HE DATASET
-                input_zip = ZipFile(join(CONFIG['inputPath'], file))
-                for zipped_xml in input_zip.namelist():  # LIST ARCHIVES IN ZIP
-                    try:
-                        zipped_xml = ZipFile(BytesIO(input_zip.read(zipped_xml)))
-                        # SUPPOSED ONLY ONE XML BUT ITERATE TO BE SURE
-                        for xml in zipped_xml.namelist():
-                            ####################################################
-                            # XML PARSER
-                            tree = ElementTree.parse(BytesIO(zipped_xml.open(xml).read()))
-                            root = tree.getroot()
-                            ####################################################
-                            # XML RELATED VARIABLES
-                            acc_type, siren, year = (None,) * 3
-                            identity_writen = False
-                            ####################################################
-                            # ITERATE ALL TAGS
-                            for child in root[0]:
-                                ################################################
-                                # IDENTITY TAGS, SIREN AND TYPE OF ACCOUNTABILITY
-                                if child.tag == "{fr:inpi:odrncs:bilansSaisisXML}identite":
-                                    acc_type, siren, denomination, year, ape, \
-                                    postal_code, town, code_motif, \
-                                    code_confidentialite, info_traitement = read_identity_data(child)
-                                    ############################################
-                                    # WRITE IDENTITY FILE IF ACCOUNT TYPE IS
-                                    # KNOWN
-                                    if acc_type in ACC_ONT.keys():
-                                        identity_file.write(
-                                            "\t".join(
-                                                (str(siren), str(denomination), str(ape),
-                                                 str(postal_code), str(town), "\n")))
-                                        identity_writen = True
-                                        metadata_file.write(
-                                            "\t".join(
-                                                (str(siren), str(year), str(code_motif),
-                                                 str(code_confidentialite), str(info_traitement), "\n")))
-                                ################################################
-                                # BUNDLE TAGS IN PAGES TO ITERATE WITH BUNDLE CODES
-                                # AND AMOUNT
-                                elif child.tag == "{fr:inpi:odrncs:bilansSaisisXML}detail":
-                                    for page in child:
-                                        for bundle in page:
-                                            try:
-                                                for bundle_code in \
-                                                        ACC_ONT[acc_type]['bundleCodeAtt']:
-                                                    if bundle.attrib["code"] in bundle_code.keys():
-                                                        for amount_code in bundle_code[bundle.attrib["code"]]:
-                                                            amount_code = "m{0}".format(amount_code)
-                                                            ####################
-                                                            # WRITE RESULTS FILE
-                                                            if identity_writen is True:
-                                                                bundle_file.write(
-                                                                    "\t".join((siren, year,
-                                                                               str(CON_ACC[acc_type]),
-                                                                               str(CON_BUN[CON_ACC[
-                                                                                   acc_type]][
-                                                                                       bundle.attrib[
-                                                                                           "code"]]),
-                                                                               str(int(
-                                                                                   bundle.attrib[
-                                                                                       amount_code]
-                                                                               )),
-                                                                               "\n")))
-                                            except KeyError as key_error:
-                                                debug("{} in account {} bundle {}".format(
-                                                    key_error,
-                                                    acc_type,
-                                                    bundle.attrib[
-                                                        "code"]
-                                                ))
-                    except UnicodeDecodeError as error:
-                        debug(error)
-            except BadZipFile as error:  #  TODO REPORT ERROR TO INPI
-                debug(error)
-    ############################################################################
-    # CLOSES RESULTS AND IDENTITY FILES
-    bundle_file.close()
-    identity_file.close()
-    metadata_file.close()
+        if file.endswith(".zip"):  # ONLY PROCESS ZIP FILES
+                process_daily_zip_file(join(CONFIG['inputPath'], file))
 
 
 if __name__ == '__main__':

--- a/python/enthic/test_extract_bundle.py
+++ b/python/enthic/test_extract_bundle.py
@@ -83,7 +83,7 @@ def result_file(config):
        :param config: Fixture of the JSON configuration file.
        :return: The file object.
     """
-    return open(join(config['outputPath'], config['bundleFile']), "r")
+    return open(join(config['outputPath'], config['tmpBundleFile']), "r")
 
 
 @pytest.fixture()
@@ -105,7 +105,7 @@ def test_result_line_data(result_file):
        :param result_file: Fixture of the CSV result file.
     """
     for line in result_file:
-        line = line.split(";")
+        line = line.split("\t")
         assert len(line) == 6, "NUMBER OF COLUMNS NOT 6"
         assert " " not in line, "BLANK ENTRY"
         assert "" not in line, "EMPTY ENTRY"
@@ -126,7 +126,7 @@ def test_identity_line_data(identity_file):
     """
     max_length = 0
     for line in identity_file:
-        line = line.split(";")
+        line = line.split("\t")
         assert len(line) == 6, "NUMBER OF COLUMNS NOT 6"
         assert " " not in line, "BLANK ENTRY"
         assert "" not in line, "EMPTY ENTRY"

--- a/python/enthic/treat_bundle.py
+++ b/python/enthic/treat_bundle.py
@@ -43,14 +43,15 @@ def main():
     ############################################################################
     # RESULT FILE
     bundle_file = open(join(CONFIG['outputPath'], CONFIG['bundleFile']), "w")
+    csv_separator = CONFIG['csvSeparator']
     ############################################################################
     # READ THE INPUT FILE AND bundle_file.write THE OUTPUT
     with open(join(CONFIG['outputPath'], CONFIG['sortTmpBundleFile']), mode='r') as infile:
-        _reader = reader(infile, delimiter='\t')  # READER OF THE INPUT CSV FILE
+        _reader = reader(infile, delimiter=csv_separator)  # READER OF THE INPUT CSV FILE
         key, bundle_sum, gain, distribution = (None,) * 4
         for rows in _reader:  # ITERATE EACH LINE
             if key is not None and key < rows[0:4]:  # KEY BREAK ON BUNDLE CODE
-                bundle_file.write(";".join((key[0], key[1], key[2], key[3],
+                bundle_file.write(csv_separator.join((key[0], key[1], key[2], key[3],
                                             str(bundle_sum), "\n"))
                                   )
             if key == rows[0:4]:  # SAME KEY, SUM THE BUNDLE AMOUNT


### PR DESCRIPTION
PR related to issue #33 : 
fix test_extract_bundle and enhance csv separator choice
Enhance regex to extract postal code and town
Add Exception to stop process on error while reading town
Refactor a little bit extract_bundle in order to reduce functions complexity