### PR TITLE
reduce time for some test and add limit to prevent timeout

### DIFF
--- a/python/enthic/app.py
+++ b/python/enthic/app.py
@@ -217,7 +217,7 @@ def result_array(probe, limit, ape_code=[], offset=0):
         return count[0][0], tuple(CompanyIdentity(*company).__dict__ for company in companies)
 
 
-def get_siren(first_letters):
+def get_siren(first_letters, limit):
     """
     Get siren of companies whose denomination starts with the given first letters
 
@@ -229,7 +229,7 @@ def get_siren(first_letters):
     with application.app_context():
         siren_list = fetchall("""SELECT siren
                         FROM identity
-                        WHERE denomination LIKE %s LIMIT 1000000""", (first_letters,))
+                        WHERE denomination LIKE %s LIMIT %s""", (first_letters, limit))
 
     return siren_list
 
@@ -377,7 +377,7 @@ def compute(first_letters):
     """
     result_list = []
     result = []
-    for siren in get_siren(first_letters):
+    for siren in get_siren(first_letters, 100):
         company_data = company_siren(siren[0])
         scores = compute_company_statistics(company_data)
         result_list.append({"siren" : siren[0], "scores" : scores})

--- a/python/enthic/test_app.py
+++ b/python/enthic/test_app.py
@@ -105,13 +105,14 @@ NOT_EXISTING_DENOMINATION = tuple(
     denomination + "ZzzzzzZ99996666" for denomination in EXISTING_DENOMINATION)
 
 LETTERS_COUPLE_LIST = []
-for first_letter in range(97,123):
-    for second_letter in range(97,123):
-        for third_letter in range(97,123):
-            LETTERS_COUPLE_LIST.append(chr(first_letter) + chr(second_letter) + chr(third_letter))
+for first_letter in range(97, 123):
+    for second_letter in range(97, 123):
+        for third_letter in range(97, 123):
+            for fourth_letter in range(97, 123):
+                LETTERS_COUPLE_LIST.append(chr(first_letter) + chr(second_letter) + chr(third_letter) + chr(fourth_letter))
 
 # Comment this line to launch compute annual statistics for the whole database
-LETTERS_COUPLE_LIST = ['aa', 'aba', 'abb', 'abc', 'abd', 'abe', 'abf' ]
+LETTERS_COUPLE_LIST = LETTERS_COUPLE_LIST[0:6]
 
 def test_ok_json_response():
     """


### PR DESCRIPTION
Reduce time for tests "test_compute_annual_statistics" and add a limit to get_siren() to prevent making server times out.
This should help with issue #34 